### PR TITLE
Input file names indices

### DIFF
--- a/src/MBIRModularDefs.h
+++ b/src/MBIRModularDefs.h
@@ -40,12 +40,11 @@ struct SinoParams3DParallel
                            /* This can be fractional though */
     int NViews;            /* Number of view angles */
     float *ViewAngles;     /* Array of NTheta view angle entries in degrees */
-    
-    int NSlices;            /* Number of rows (slices) stored in Sino array */
+    int NSlices;           /* Number of rows (slices) stored in Sino array */
     float DeltaSlice;      /* Spacing along row (slice) direction (mm) */
-    int FirstSliceNumber;   /* Row (slice) index coresponding to first row (slice) stored in Sino array */
-                            /* This is in absolute coordinates and is used if a partial set of slices is needed */
-                            /* Otherwise, it is set to 0. */
+    int FirstSliceNumber;  /* Row (slice) index coresponding to first row (slice) stored in Sino array */
+                           /* This is in absolute coordinates and is used if a partial set of slices is needed */
+    int NumSliceDigits;    /* Number of slice numbers digits used in file name */
 };
 
 /* 3D Sinogram Data Structure */
@@ -64,12 +63,11 @@ struct ImageParams3D
     int Ny;                 /* Number of rows in image */
     float Deltaxy;          /* Spacing between pixels in x and y direction (mm) */
     float ROIRadius;        /* Radius of the reconstruction (mm) */
-    
     float DeltaZ;           /* Spacing between pixels in z direction (mm) [This should be equal to DeltaSlice */
     int Nz;                 /* Number of rows (slices) in image */
     int FirstSliceNumber;   /* Detector row (slice) index cooresponding to first row (slice) stored in Image array */
                             /* This is in absolute coordinates and is used if a partial set of slices is needed */
-                            /* Otherwise, it is set to 0. */
+    int NumSliceDigits;     /* Number of slice numbers digits used in file name */
 };
 
 /* 3D Image Data Structure */

--- a/src/MBIRModularUtils.c
+++ b/src/MBIRModularUtils.c
@@ -577,11 +577,11 @@ int ReadSinoData3DParallel(
     
     for(i=0;i<NSlices;i++)
     {
-        /* slice index currently formed from fixed number of digits */
-        sprintf(fname,"%s_slice%.*d.2Dsinodata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
+        sprintf(fname,"%s_slice%.*d.2Dsinodata",basename, sinogram->sinoparams.NumSliceDigits, i+FirstSliceNumber);
+        //sprintf(fname,"%s_slice%.*d.2Dsinodata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
 	//printf("filename: |%s|\n",fname);
         
-        if( exitcode=ReadFloatArray(fname,sinogram->sino[i],M) ) {
+        if( (exitcode=ReadFloatArray(fname,sinogram->sino[i],M)) ) {
             if(exitcode==1)
 		fprintf(stderr, "ERROR in ReadSinoData3DParallel: can't open file %s\n",fname);
             if(exitcode==2)
@@ -609,11 +609,11 @@ int ReadWeights3D(
 
     for(i=0;i<NSlices;i++)
     {
-        /* slice index currently formed from fixed number of digits */
-        sprintf(fname,"%s_slice%.*d.2Dweightdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
+        sprintf(fname,"%s_slice%.*d.2Dweightdata",basename, sinogram->sinoparams.NumSliceDigits, i+FirstSliceNumber);
+        //sprintf(fname,"%s_slice%.*d.2Dweightdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
 	//printf("filename: |%s|\n",fname);
         
-        if( exitcode=ReadFloatArray(fname,sinogram->weight[i],M) ) {
+        if( (exitcode=ReadFloatArray(fname,sinogram->weight[i],M)) ) {
             if(exitcode==1)
 		fprintf(stderr, "ERROR in ReadWeights3D: can't open file %s\n",fname);
             if(exitcode==2)
@@ -640,11 +640,11 @@ int WriteSino3DParallel(
 
     for(i=0;i<NSlices;i++)
     {
-        /* slice index currently formed from fixed number of digits */
-        sprintf(fname,"%s_slice%.*d.2Dsinodata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
+        sprintf(fname,"%s_slice%.*d.2Dsinodata",basename, sinogram->sinoparams.NumSliceDigits, i+FirstSliceNumber);
+        //sprintf(fname,"%s_slice%.*d.2Dsinodata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
 	//printf("filename: |%s|\n",fname);
         
-        if( exitcode=WriteFloatArray(fname,sinogram->sino[i],M) ) {
+        if( (exitcode=WriteFloatArray(fname,sinogram->sino[i],M)) ) {
             if(exitcode==1)
 		fprintf(stderr, "ERROR in WriteSino3DParallel: can't open file %s\n",fname);
             if(exitcode==2)
@@ -671,11 +671,11 @@ int WriteWeights3D(
 
     for(i=0;i<NSlices;i++)
     {
-        /* slice index currently formed from fixed number of digits */
-        sprintf(fname,"%s_slice%.*d.2Dweightdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
+        sprintf(fname,"%s_slice%.*d.2Dweightdata",basename, sinogram->sinoparams.NumSliceDigits, i+FirstSliceNumber);
+        //sprintf(fname,"%s_slice%.*d.2Dweightdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
 	//printf("filename: |%s|\n",fname);
         
-        if( exitcode=WriteFloatArray(fname,sinogram->weight[i],M) ) {
+        if( (exitcode=WriteFloatArray(fname,sinogram->weight[i],M)) ) {
             if(exitcode==1)
 		fprintf(stderr, "ERROR in WriteWeights3D: can't open file %s\n",fname);
             if(exitcode==2)
@@ -726,11 +726,11 @@ int ReadImage3D(
     
     for(i=0;i<Nz;i++)
     {
-        /* slice index currently formed from fixed number of digits */
-        sprintf(fname,"%s_slice%.*d.2Dimgdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
+        sprintf(fname,"%s_slice%.*d.2Dimgdata",basename, Image->imgparams.NumSliceDigits, i+FirstSliceNumber);
+        //sprintf(fname,"%s_slice%.*d.2Dimgdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
 	//printf("filename: |%s|\n",fname);
         
-        if( exitcode=ReadFloatArray(fname,Image->image[i],M) ) {
+        if( (exitcode=ReadFloatArray(fname,Image->image[i],M)) ) {
             if(exitcode==1)
 		fprintf(stderr, "ERROR in ReadImage3D: can't open file %s\n",fname);
             if(exitcode==2)
@@ -756,11 +756,11 @@ int WriteImage3D(
     
     for(i=0;i<Nz;i++)
     {
-        /* slice index currently formed from fixed number of digits */
-        sprintf(fname,"%s_slice%.*d.2Dimgdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
+        sprintf(fname,"%s_slice%.*d.2Dimgdata",basename, Image->imgparams.NumSliceDigits, i+FirstSliceNumber);
+        //sprintf(fname,"%s_slice%.*d.2Dimgdata",basename,MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS,i+FirstSliceNumber);
 	//printf("filename: |%s|\n",fname);
         
-        if( exitcode=WriteFloatArray(fname,Image->image[i],M) ) {
+        if( (exitcode=WriteFloatArray(fname,Image->image[i],M)) ) {
             if(exitcode==1)
 		fprintf(stderr, "ERROR in WriteImage3D: can't open file %s\n",fname);
             if(exitcode==2)
@@ -934,5 +934,31 @@ int FreeImageData2D(struct Image2D *Image)
     return 0;
 }
 
+
+/************************/
+/*    Other utilities   */
+/************************/
+
+/* Detect the number of slice index digits in given sinogram data file */
+/* Returns number of digits, or 0 if no readable files found */
+int NumSinoSliceDigits(char *basename, int slice)
+{
+    FILE *fp;
+    char fname[200];
+    int Ndigits = MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS;
+
+    while(Ndigits > 0)
+    {
+        sprintf(fname,"%s_slice%.*d.2Dsinodata",basename, Ndigits, slice);
+        //printf("%s\n",fname);
+        if( (fp=fopen(fname,"r")) ) {
+            fclose(fp);
+            break;
+        }
+        else
+            Ndigits--;
+    }
+    return(Ndigits);
+}
 
 

--- a/src/MBIRModularUtils.h
+++ b/src/MBIRModularUtils.h
@@ -159,6 +159,15 @@ int FreeImageData2D(
 	struct Image2D *Image);  /* 2D Image data+params data structure */
 
 
+/************************/
+/*    Other utilities   */
+/************************/
+
+/* Detect the number of slice index digits in given sinogram data file */
+/* Returns number of digits, or 0 if no readable files found */
+int NumSinoSliceDigits(char *basename, int slice);
+
+
 
 #endif /* MBIR_MODULAR_UTILS_H */
 

--- a/src/initialize_3D.c
+++ b/src/initialize_3D.c
@@ -178,7 +178,7 @@ void readCmdLineMBIR(int argc, char *argv[], struct CmdLineMBIR *cmdline)
     }
     
     /* get options */
-    while ((ch = getopt(argc, argv, "i:j:k:m:s:w:r:t:v")) != EOF)
+    while ((ch = getopt(argc, argv, "i:j:k:m:s:w:r:t:p:v")) != EOF)
     {
         switch (ch)
         {
@@ -222,6 +222,14 @@ void readCmdLineMBIR(int argc, char *argv[], struct CmdLineMBIR *cmdline)
                 sprintf(cmdline->InitImageDataFile, "%s", optarg);
                 break;
             }
+            case 'p':
+            {
+                sprintf(cmdline->ProxMapImageDataFile, "%s", optarg);
+                fprintf(stderr,"Error: -p option -> Proximal Map prior yet to be implemented\n");
+                PrintCmdLineUsage(argv[0]);
+                exit(-1);
+                break;
+            }
             // Reserve this for verbose-mode flag
             case 'v':
             {
@@ -229,7 +237,7 @@ void readCmdLineMBIR(int argc, char *argv[], struct CmdLineMBIR *cmdline)
             }
             default:
             {
-                printf("\nError : Command line symbol not recongized\n");
+                fprintf(stderr,"Error : Command line symbol not recongized\n");
                 PrintCmdLineUsage(argv[0]);
                 exit(-1);
                 break;
@@ -241,25 +249,27 @@ void readCmdLineMBIR(int argc, char *argv[], struct CmdLineMBIR *cmdline)
 
 void PrintCmdLineUsage(char *ExecFileName)
 {
-    fprintf(stdout, "\nBASELINE MBIR RECONSTRUCTION SOFTWARE FOR 3D PARALLEL-BEAM  CT \n");
+    fprintf(stdout, "\nBASELINE MBIR RECONSTRUCTION SOFTWARE FOR 3D PARALLEL-BEAM  CT\n");
     fprintf(stdout, "build time: %s, %s\n", __DATE__,  __TIME__);
-    fprintf(stdout, "\nCommand line Format for Executable File %s : \n", ExecFileName);
+    fprintf(stdout, "\nCommand line Format for Executable File %s :\n", ExecFileName);
     fprintf(stdout, "%s -i <InputFileName>[.imgparams] -j <InputFileName>[.sinoparams]\n",ExecFileName);
     fprintf(stdout, "   -k <InputFileName>[.reconparams] -m <InputFileName>[.2Dsysmatrix]\n");
     fprintf(stdout, "   -s <InputProjectionsBaseFileName> -w <InputWeightsBaseFileName>\n");
     fprintf(stdout, "   -r <OutputImageBaseFileName>\n\n");
-    fprintf(stdout, "Additional option to read in initial image: -t <InitialImageBaseFileName> \n\n");
+    fprintf(stdout, "Additional options:\n");
+    fprintf(stdout, "   -t <InitialImageBaseFileName>   # Read initial image\n");
+    fprintf(stdout, "   -p <ProxMapImageBaseFileName>   # Read/run Proximal Map prior (TBD)\n\n");
     fprintf(stdout, "Note : The necessary extensions for certain input files are mentioned above within\n");
     fprintf(stdout, "a \"[]\" symbol above, however the extensions should be OMITTED in the command line\n\n");
-    fprintf(stdout, "The following instructions pertain to the -s, -w and -r options: \n");
+    fprintf(stdout, "The following instructions pertain to the -s, -w and -r options:\n");
     fprintf(stdout, "A) The Sinogram Projection data files should be stored slice by slice in a single\n");
     fprintf(stdout, "   directory. All files within this directory must share a common BaseFileName and\n");
     fprintf(stdout, "   adhere to the following format :\n");
-    fprintf(stdout, "      <ProjectionsBaseFileName>_slice<SliceIndex>.2Dsinodata \n");
+    fprintf(stdout, "      <ProjectionsBaseFileName>_slice<SliceIndex>.2Dsinodata\n");
     fprintf(stdout, "   where \"SliceIndex\" is a non-negative integer indexing each slice and is printed\n");
-    fprintf(stdout, "   with 4 digits. Eg : 0000 to 9999 is a valid descriptor for \"SliceIndex\" \n");
+    fprintf(stdout, "   with a fixed number of digits. Eg. 000 to 999 OR 0000 to 9999 would be valid.\n");
     fprintf(stdout, "B) Similarly, the format for the Sinogram Weights files is :\n");
-    fprintf(stdout, "      <WeightsBaseFileName>_slice<SliceIndex>.2Dweightdata \n");
+    fprintf(stdout, "      <WeightsBaseFileName>_slice<SliceIndex>.2Dweightdata\n");
     fprintf(stdout, "C) Similarly, the Reconstructed (Output) Image is organized slice by slice :\n");
     fprintf(stdout, "      <ImageBaseFileName>_slice<SliceIndex>.2Dimgdata\n\n");
 }

--- a/src/initialize_3D.c
+++ b/src/initialize_3D.c
@@ -112,7 +112,7 @@ void readSystemParams  (
                          struct SinoParams3DParallel *sinoparams,
                          struct ReconParamsQGGMRF3D *reconparams)
 {
-    printf("\nReading Image, Sinogram and Reconstruction Parameters ... \n");
+    //printf("\nReading Image, Sinogram and Reconstruction Parameters ... \n");
     
     if(ReadImageParams3D(cmdline->ImageParamsFile, imgparams))
       {
@@ -129,7 +129,7 @@ void readSystemParams  (
         fprintf(stdout,"Error in reading reconstruction parameters \n");
         exit(-1);
       }
-          
+
     /* Tentatively initialize weights. Remove once this is read in directly from params file */
     NormalizePriorWeights3D(reconparams);
     
@@ -137,6 +137,21 @@ void readSystemParams  (
     printImageParams3D(imgparams);
     printSinoParams3DParallel(sinoparams);
     printReconParamsQGGMRF3D(reconparams);
+    fprintf(stdout,"\n");
+
+    /* Determine and SET number of slice index digits in data files */
+    int Ndigits = NumSinoSliceDigits(cmdline->SinoDataFile, sinoparams->FirstSliceNumber);
+    if(Ndigits==0)
+    {
+        fprintf(stderr,"Error: Can't read the first data file. Looking for any one of the following:\n");
+        for(int i=MBIR_MODULAR_MAX_NUMBER_OF_SLICE_DIGITS; i>0; i--)
+            fprintf(stderr,"\t%s_slice%.*d.2Dsinodata\n",cmdline->SinoDataFile, i, sinoparams->FirstSliceNumber);
+        exit(-1);
+    }
+    //printf("Detected %d slice index digits\n",Ndigits);
+    sinoparams->NumSliceDigits = Ndigits;
+    imgparams->NumSliceDigits = Ndigits;
+
 }
 
 /* Read Command-line */

--- a/src/initialize_3D.h
+++ b/src/initialize_3D.h
@@ -5,14 +5,15 @@
 
 struct CmdLineMBIR{
     
-    char ImageParamsFile[200];
-    char InitImageDataFile[200]; /* optional input */
-    char ReconImageDataFile[200]; /* output */
     char SinoParamsFile[200];
+    char ImageParamsFile[200];
+    char ReconParamsFile[200];
     char SinoDataFile[200];
     char SinoWeightsFile[200];
-    char ReconParamsFile[200];
+    char ReconImageDataFile[200]; /* output */
     char SysMatrixFile[200];
+    char InitImageDataFile[200]; /* optional input */
+    char ProxMapImageDataFile[200]; /* optional input */
 };
 
 


### PR DESCRIPTION
This contains an update that gives flexibility in file name indexing. Previously it was fixed at 4 digits, e.g. "input_slice0001.2Dsinodata".  Now it just requires consistency in the number of digits used throughout the data set. It detects the number of digits by checking the existence of the first specified sinogram file, in order, (assuming FirstSliceNumber==1)  :
  input_slice0001.2Dsinodata
  input_slice001.2Dsinodata
  input_slice01.2Dsinodata
  input_slice1.2Dsinodata
The maximum number of digits (currently 4) is set by a #define in MBIRModularDefs.h
The detected number of digits is carried through to the output images, and initial image if specified.

Unrelated, I added a place holder in the command line parsing and struct for the Proximal Map prior. 