### PR TITLE
Fixed recon slice range

### DIFF
--- a/src/MBIRModularUtils.c
+++ b/src/MBIRModularUtils.c
@@ -20,10 +20,10 @@ void printSinoParams3DParallel(struct SinoParams3DParallel *sinoparams)
     fprintf(stdout, " - Number of sinogram views per slice    = %d\n", sinoparams->NViews);
     fprintf(stdout, " - Number of detector channels per slice = %d\n", sinoparams->NChannels);
     fprintf(stdout, " - Number of slices                      = %d\n", sinoparams->NSlices);
-    fprintf(stdout, " - Spacing between Detector Channels     = %.7f (mm) \n", sinoparams->DeltaChannel);
+    fprintf(stdout, " - First slice index (wrt file names)    = %d\n", sinoparams->FirstSliceNumber);
+    fprintf(stdout, " - Spacing between detector channels     = %.7f (mm)\n", sinoparams->DeltaChannel);
     fprintf(stdout, " - Center of rotation offset             = %.7f (channels)\n", sinoparams->CenterOffset);
     fprintf(stdout, " - Spacing between slices                = %.7f (mm)\n", sinoparams->DeltaSlice);
-    fprintf(stdout, " - First Slice Index                     = %d \n", sinoparams->FirstSliceNumber);
 }
 
 /* Utility for reading 3D parallel beam sinogram parameters */
@@ -181,13 +181,12 @@ int ReadSinoParams3DParallel(
 void printImageParams3D(struct ImageParams3D *imgparams)
 {
     fprintf(stdout, "IMAGE PARAMETERS:\n");
-    fprintf(stdout, " - Number of Pixels within a single slice in X direction = %d\n", imgparams->Nx);
-    fprintf(stdout, " - Number of Pixels within a single slice in Y direction = %d\n", imgparams->Ny);
-    fprintf(stdout, " - Number of Slices to reconstruct                       = %d \n", imgparams->Nz);
-    fprintf(stdout, " - Pixel width  in XY plane                              = %.7f (mm)\n", imgparams->Deltaxy);
-    fprintf(stdout, " - Spacing between slices                                = %.7f (mm)\n", imgparams->DeltaZ);
-    fprintf(stdout, " - First Slice Index                                     = %d \n", imgparams->FirstSliceNumber);
-    fprintf(stdout, " - ROIRadius                                             = %.7f (mm)\n", imgparams->ROIRadius);
+    fprintf(stdout, " - Number of pixels per slice in (X,Y)-directions    = (%d,%d)\n",imgparams->Nx,imgparams->Ny);
+    fprintf(stdout, " - Number of slices (to reconstruct if output param) = %d\n",imgparams->Nz);
+    fprintf(stdout, " - First slice index (wrt sino/img file names)       = %d\n",imgparams->FirstSliceNumber);
+    fprintf(stdout, " - Pixel width in XY plane               = %.7f (mm)\n", imgparams->Deltaxy);
+    fprintf(stdout, " - Spacing between slices                = %.7f (mm)\n", imgparams->DeltaZ);
+    fprintf(stdout, " - ROIRadius                             = %.7f (mm)\n", imgparams->ROIRadius);
 }
 
 /* Utility for reading 2D Image parameters */
@@ -309,7 +308,7 @@ int ReadImageParams3D(
 /* Print QGGMRF reconstruction parameters */
 void printReconParamsQGGMRF3D(struct ReconParamsQGGMRF3D *reconparams)
 {
-    fprintf(stdout, "PRIOR PARAMETERS:\n");
+    fprintf(stdout, "RECONSTRUCTION/PRIOR PARAMETERS:\n");
     fprintf(stdout, " - Q-GGMRF Prior Parameter, q                            = %f\n", reconparams->p);
     fprintf(stdout, " - Q-GGMRF Prior Parameter, p                            = %f\n", reconparams->q);
     fprintf(stdout, " - Q-GGMRF Prior Parameter, T                            = %f\n", reconparams->T);

--- a/src/icd_3D.c
+++ b/src/icd_3D.c
@@ -7,14 +7,14 @@
 
 
 float ICDStep3D(
-	float **e,  /* e=y-AX */
-	float **w,
+    float **e,  /* e=y-AX */
+    float **w,
     struct SysMatrix2D *A,
-	struct ICDInfo *icd_info)
+    struct ICDInfo *icd_info)
 {
-	int i, n, Nxy, XYPixelIndex, SliceIndex;
+    int i, n, Nxy, XYPixelIndex, SliceIndex;
     struct SparseColumn A_column;
-	float UpdatedVoxelValue;
+    float UpdatedVoxelValue;
 
     Nxy = icd_info->Nxy; /* No. of pixels within a given slice */
     
@@ -25,16 +25,15 @@ float ICDStep3D(
     A_column = A->column[XYPixelIndex]; /* System matrix does not vary with slice for 3-D Parallel beam geometry */
     
     /* Formulate the quadratic surrogate function (with coefficients theta1, theta2) for the local cost function */
-	icd_info->theta1 = 0.0;
-	icd_info->theta2 = 0.0;
-    
-	for (n = 0; n < A_column.Nnonzero; n++)
-	{
-		i = A_column.RowIndex[n] ; /* (View, Detector-Channel) index pertaining to same slice as voxel */
-        
+    icd_info->theta1 = 0.0;
+    icd_info->theta2 = 0.0;
+   
+    for (n = 0; n < A_column.Nnonzero; n++)
+    {
+        i = A_column.RowIndex[n] ; /* (View, Detector-Channel) index pertaining to same slice as voxel */
         icd_info->theta1 -= A_column.Value[n]*w[SliceIndex][i]*e[SliceIndex][i];
         icd_info->theta2 += A_column.Value[n]*w[SliceIndex][i]*A_column.Value[n];
-	}
+    }
    
     /* theta1 and theta2 must be further adjusted according to Prior Model */
     /* Step can be skipped if merely ML estimation (no prior model) is followed rather than MAP estimation */
@@ -43,7 +42,7 @@ float ICDStep3D(
     /* Calculate Updated Pixel Value */
     UpdatedVoxelValue = icd_info->v - (icd_info->theta1/icd_info->theta2) ;
     
-	return UpdatedVoxelValue;
+    return UpdatedVoxelValue;
 }
 
 /* ICD update with the QGGMRF prior model */
@@ -186,10 +185,10 @@ void ExtractNeighbors3D(
 
 /* Update error term e=y-Ax after an ICD update on x */
 void UpdateError3D(
-                   float **e,
-                   struct SysMatrix2D *A,
-                   float diff,
-                   struct ICDInfo *icd_info)
+    float **e,
+    struct SysMatrix2D *A,
+    float diff,
+    struct ICDInfo *icd_info)
 {
     int n, i, XYPixelIndex, SliceIndex;
     int Nxy;
@@ -208,6 +207,5 @@ void UpdateError3D(
         e[SliceIndex][i] -= A->column[XYPixelIndex].Value[n]*diff;
     }
 }
-
 
 

--- a/src/initialize_3D.c
+++ b/src/initialize_3D.c
@@ -9,47 +9,49 @@
 #include "allocate.h"
 #include "initialize_3D.h"
 
-/* Initialize constant image */
-void Initialize_Image(struct Image3D *Image, struct CmdLineMBIR *cmdline, float InitValue)
+/* Initialize image state */
+void Initialize_Image(
+	struct Image3D *Image,
+	struct CmdLineMBIR *cmdline,
+	char *ImageReconMask,
+	float InitValue,
+	float OutsideROIValue)
 {
+    int j,jz;
+    int Nxy = Image->imgparams.Nx * Image->imgparams.Ny;
+    int Nz = Image->imgparams.Nz;
+
     fprintf(stdout, "\nInitializing Image ... \n");
-    
+
     if(strcmp(cmdline->InitImageDataFile,"NA") == 0) /* Image file not available */
-        GenConstImage(Image, InitValue);               /* generate image with uniform pixel value */
-    else
-        ReadImage3D(cmdline->InitImageDataFile, Image); /* read image which has values in HU units */
-}
-
-/* create constant image. Each pixel value is the intial condition. */
-void GenConstImage(struct Image3D *Image, float value)
-{
-    int jxy, jz, Nxy, Nz;
-    Nxy = Image->imgparams.Nx * Image->imgparams.Ny ;
-    Nz = Image->imgparams.Nz;
-
-    for (jz = 0; jz < Nz; jz++)
-    for (jxy = 0; jxy < Nxy; jxy++)
     {
-        Image->image[jz][jxy] = value;
+        /* Generate constant image */
+        for(jz=0; jz<Nz; jz++)
+        for(j=0; j<Nxy; j++)
+        if(ImageReconMask[j]==0) 
+            Image->image[jz][j] = OutsideROIValue;
+        else
+            Image->image[jz][j] = InitValue;
     }
+    else 
+        ReadImage3D(cmdline->InitImageDataFile, Image);
+
 }
 
-/* Generate Image Reconstruction mask */
-char *GenImageReconMask (struct Image3D *Image, float OutsideROIValue)
+/* Allocate and generate Image Reconstruction mask */
+char *GenImageReconMask(struct ImageParams3D *imgparams)
 {
-    int jx, jy, jz, Nx, Ny, Nz, Nxy;
+    int jx, jy, jz, Nx, Ny, Nz;
     float x_0, y_0, Deltaxy, x, y, yy, ROIRadius, R_sq, R_sq_max;
     char *ImageReconMask;
     
-    Nx = Image->imgparams.Nx;
-    Ny = Image->imgparams.Ny;
-    Nz = Image->imgparams.Nz;
-    Deltaxy = Image->imgparams.Deltaxy;
-    ROIRadius = Image->imgparams.ROIRadius;
-    
+    Nx = imgparams->Nx;
+    Ny = imgparams->Ny;
+    Nz = imgparams->Nz;
+    Deltaxy = imgparams->Deltaxy;
+    ROIRadius = imgparams->ROIRadius;
     x_0 = -(Nx-1)*Deltaxy/2;
     y_0 = -(Ny-1)*Deltaxy/2;
-    Nxy = Nx*Ny;
     
     /* Reconstruction Mask same for each slice, hence 2-D */
     ImageReconMask = (char *)get_spc(Ny*Nx,sizeof(char));
@@ -70,18 +72,11 @@ char *GenImageReconMask (struct Image3D *Image, float OutsideROIValue)
             for (jx = 0; jx < Nx; jx++)
             {
                 x = x_0 + jx*Deltaxy;
-                
                 R_sq = x*x + yy;
                 if (R_sq > R_sq_max)
-                {
                     ImageReconMask[jy*Nx+jx] = 0;
-                    for(jz=0;jz<Nz;jz++)
-                        Image->image[jz][jy*Nx+jx] = OutsideROIValue;
-                }
                 else
-                {
                     ImageReconMask[jy*Nx+jx] = 1;
-                }
             }
         }
     }

--- a/src/initialize_3D.h
+++ b/src/initialize_3D.h
@@ -17,10 +17,18 @@ struct CmdLineMBIR{
 };
 
 
-void Initialize_Image(struct Image3D *Image, struct CmdLineMBIR *cmdline, float InitValue);
-void GenConstImage(struct Image3D *Image, float value);
-char *GenImageReconMask (struct Image3D *Image, float OutsideROIValue);
-void readSystemParams ( struct CmdLineMBIR *cmdline, struct ImageParams3D *imgparams, struct SinoParams3DParallel *sinoparams, struct ReconParamsQGGMRF3D *reconparams);
+void Initialize_Image(
+	struct Image3D *Image,
+	struct CmdLineMBIR *cmdline,
+	char *ImageReconMask,
+	float InitValue,
+	float OutsideROIValue);
+char *GenImageReconMask(struct ImageParams3D *imgparams);
+void readSystemParams(
+	struct CmdLineMBIR *cmdline,
+	struct ImageParams3D *imgparams,
+	struct SinoParams3DParallel *sinoparams,
+	struct ReconParamsQGGMRF3D *reconparams);
 void NormalizePriorWeights3D(struct ReconParamsQGGMRF3D *reconparams);
 void readCmdLineMBIR(int argc, char *argv[], struct CmdLineMBIR *cmdline);
 void PrintCmdLineUsage(char *ExecFileName);

--- a/src/mbir_3D.c
+++ b/src/mbir_3D.c
@@ -11,7 +11,7 @@
 
 int main(int argc, char *argv[])
 {
-	struct Image3D Image;
+    struct Image3D Image;
     struct Sino3DParallel sinogram;
     struct ReconParamsQGGMRF3D reconparams;
     struct SysMatrix2D A;
@@ -22,11 +22,16 @@ int main(int argc, char *argv[])
                           /* else intialize it to a uniform image with value InitValue */
     float OutsideROIValue;/* Image pixel value outside ROI Radius */
     
-	/* read command line */
-	readCmdLineMBIR(argc, argv, &cmdline);
+    /* read command line */
+    readCmdLineMBIR(argc, argv, &cmdline);
     
     /* read parameters */
-    readSystemParams (&cmdline, &Image.imgparams, &sinogram.sinoparams, &reconparams);
+    readSystemParams(&cmdline, &Image.imgparams, &sinogram.sinoparams, &reconparams);
+
+    /* The image parameters specify the relevant slice range to reconstruct, so re-set the  */
+    /* relevant sinogram parameters so it pulls the correct slices/weights and indexes them consistently */
+    sinogram.sinoparams.NSlices = Image.imgparams.Nz;
+    sinogram.sinoparams.FirstSliceNumber = Image.imgparams.FirstSliceNumber;
     
     /* Read Sinogram and Weights */
     if(AllocateSinoData3DParallel(&sinogram))

--- a/src/mbir_3D.c
+++ b/src/mbir_3D.c
@@ -59,11 +59,14 @@ int main(int argc, char *argv[])
     {   fprintf(stderr, "Error in allocating memory for image through function AllocateImageData3D \n");
         exit(-1);
     }
+
+    /* Allocate and generate recon mask based on ROIRadius--do this before image initialization */
+    ImageReconMask = GenImageReconMask(&(Image.imgparams));
+
     /* Initialize image and reconstruction mask */
     InitValue = reconparams.InitImageValue;
     OutsideROIValue = 0;
-    Initialize_Image(&Image, &cmdline, InitValue);
-    ImageReconMask = GenImageReconMask(&Image,OutsideROIValue);
+    Initialize_Image(&Image, &cmdline, ImageReconMask, InitValue, OutsideROIValue);
     
     /* MBIR - Reconstruction */
     MBIRReconstruct3D(&Image,&sinogram,reconparams,&A,ImageReconMask);

--- a/src/recon_3D.c
+++ b/src/recon_3D.c
@@ -57,9 +57,11 @@ void MBIRReconstruct3D(
     /* Initialize error to zero, since it is first computed as forward-projection Ax */
     for (jz = 0; jz < Nz; jz++)
     for (i = 0; i < M; i++)
-    e[jz][i]=0;
+        e[jz][i]=0;
+
     /* compute Ax (store it in e as of now) */
     forwardProject3D(e, Image, A);
+
     /* Compute the initial error e=y-Ax */
     for (jz = 0; jz < Nz; jz++)
     for (i = 0; i < M; i++)
@@ -78,7 +80,7 @@ void MBIRReconstruct3D(
     /* Order of pixel updates need NOT be raster order, just initialize */
     order = (int *)get_spc(N, sizeof(int));
     for (j = 0; j < N; j++)
-    order[j] = j;
+        order[j] = j;
     
     stop_FLAG = 0;
     start = time(NULL);  /* XW: starting time */
@@ -144,44 +146,35 @@ void MBIRReconstruct3D(
                         TotalVoxelValue += icd_info.v ; /* using previous pixel value here */
                         NumUpdatedVoxels++ ;
                 }
-                
             }
         }
         
-        
-         cost = MAPCostFunction3D(e, Image, sinogram, &reconparams);
-         if(NumUpdatedVoxels>0)
-         {
-           avg_update = TotalValueChange/NumUpdatedVoxels;
-           AvgVoxelValue = TotalVoxelValue/NumUpdatedVoxels;
-           if(AvgVoxelValue>0)
-           ratio = (avg_update/AvgVoxelValue)*100;
-         }
-         else
-         avg_update=0;
+        cost = MAPCostFunction3D(e, Image, sinogram, &reconparams);
+        if(NumUpdatedVoxels>0)
+        {
+            avg_update = TotalValueChange/NumUpdatedVoxels;
+            AvgVoxelValue = TotalVoxelValue/NumUpdatedVoxels;
+            if(AvgVoxelValue>0)
+                ratio = (avg_update/AvgVoxelValue)*100;
+        }
+        else
+            avg_update=0;
         
         fprintf(stdout, "cost = %-15f, Average Update = %f mm^{-1} \n", cost, avg_update);
         
         if (ratio < StopThreshold || NumUpdatedVoxels==0)
-        {
             stop_FLAG = 1;
-        }
     }
     
     fprintf(stdout, "\nTime elapsed in Iterative reconstruction is %f seconds\n", difftime(time(NULL), start));
     
     if (stop_FLAG == 1)
-    {
         fprintf(stdout, "Reached stopping condition.\n");
-    }
     else if (StopThreshold> 0)
-    {
         fprintf(stdout, "WARNING: Didn't reach stopping condition.\n");
-    }
     
     if(AvgVoxelValue>0)
     fprintf(stdout, "Average Update to Average Voxel-Value Ratio = %f %% \n", ratio);
-    
     
     free((void *)order);
 }
@@ -189,67 +182,62 @@ void MBIRReconstruct3D(
 
 /* The function to compute cost function */
 float MAPCostFunction3D(
-	float **e,
+    float **e,
     struct Image3D *Image,
-	struct Sino3DParallel *sinogram,
+    struct Sino3DParallel *sinogram,
     struct ReconParamsQGGMRF3D *reconparams)
 {
-	int i, M, jx, jy, jz, jxy, Nx, Ny, Nz, Nxy, plusx, minusx, plusy, plusz ;
+    int i, M, jx, jy, jz, jxy, Nx, Ny, Nz, Nxy, plusx, minusx, plusy, plusz ;
     float **x ;
     float **w ;
-	float nloglike, nlogprior_nearest, nlogprior_diag, nlogprior_interslice ;
+    float nloglike, nlogprior_nearest, nlogprior_diag, nlogprior_interslice ;
     
     x = Image->image;
     w = sinogram->weight;
     
-	M = sinogram->sinoparams.NViews * sinogram->sinoparams.NChannels ;
-	Nx = Image->imgparams.Nx;
-	Ny = Image->imgparams.Ny;
+    M = sinogram->sinoparams.NViews * sinogram->sinoparams.NChannels ;
+    Nx = Image->imgparams.Nx;
+    Ny = Image->imgparams.Ny;
     Nz = Image->imgparams.Nz; 
-
     Nxy = Nx*Ny;
     
-	nloglike = 0.0;
+    nloglike = 0.0;
 
     for (jz = 0; jz < Nz; jz++)
-	for (i = 0; i < M; i++)
-    nloglike += e[jz][i]*w[jz][i]*e[jz][i];
+    for (i = 0; i < M; i++)
+        nloglike += e[jz][i]*w[jz][i]*e[jz][i];
 
-	nloglike /= 2.0;
-	nlogprior_nearest = 0.0;
-	nlogprior_diag = 0.0;
+    nloglike /= 2.0;
+    nlogprior_nearest = 0.0;
+    nlogprior_diag = 0.0;
     nlogprior_interslice = 0.0;
     
-   for (jz = 0; jz < Nz; jz++)
-  {
-	for (jy = 0; jy < Ny; jy++)
-	{
-		for (jx = 0; jx < Nx; jx++)
-		{
-			plusx = jx + 1;
-			plusx = ((plusx < Nx) ? plusx : 0);
-			minusx = jx - 1;
-			minusx = ((minusx < 0) ? Nx-1 : minusx);
-			plusy = jy + 1;
-			plusy = ((plusy < Ny) ? plusy : 0);
-            plusz = jz + 1;
-            plusz = ((plusz < Nz) ? plusz : 0);
+    for (jz = 0; jz < Nz; jz++)
+    for (jy = 0; jy < Ny; jy++)
+    for (jx = 0; jx < Nx; jx++)
+    {
+        plusx = jx + 1;
+        plusx = ((plusx < Nx) ? plusx : 0);
+        minusx = jx - 1;
+        minusx = ((minusx < 0) ? Nx-1 : minusx);
+        plusy = jy + 1;
+        plusy = ((plusy < Ny) ? plusy : 0);
+        plusz = jz + 1;
+        plusz = ((plusz < Nz) ? plusz : 0);
 
-			jxy = jy*Nx + jx; /* XY pixel Index */
+        jxy = jy*Nx + jx; /* XY pixel Index */
 
-            /* Trick to avoid computing the contribution of pair-wise cliques twice */
-            nlogprior_nearest += QGGMRF_Potential((x[jz][jxy] - x[jz][jy*Nx+plusx]), reconparams);
-            nlogprior_nearest += QGGMRF_Potential((x[jz][jxy] - x[jz][plusy*Nx+jx]),reconparams);
+        /* Trick to avoid computing the contribution of pair-wise cliques twice */
+        nlogprior_nearest += QGGMRF_Potential((x[jz][jxy] - x[jz][jy*Nx+plusx]), reconparams);
+        nlogprior_nearest += QGGMRF_Potential((x[jz][jxy] - x[jz][plusy*Nx+jx]),reconparams);
 
-            nlogprior_diag += QGGMRF_Potential((x[jz][jxy] - x[jz][plusy*Nx+minusx]),reconparams);
-            nlogprior_diag += QGGMRF_Potential((x[jz][jxy] - x[jz][plusy*Nx+plusx]),reconparams);
-            
-            nlogprior_interslice += QGGMRF_Potential((x[jz][jxy] - x[plusz][jxy]),reconparams);
-		}
-	}
-  }
+        nlogprior_diag += QGGMRF_Potential((x[jz][jxy] - x[jz][plusy*Nx+minusx]),reconparams);
+        nlogprior_diag += QGGMRF_Potential((x[jz][jxy] - x[jz][plusy*Nx+plusx]),reconparams);
 
-	return (nloglike + reconparams->b_nearest * nlogprior_nearest + reconparams->b_diag * nlogprior_diag + reconparams->b_interslice * nlogprior_interslice) ;
+        nlogprior_interslice += QGGMRF_Potential((x[jz][jxy] - x[plusz][jxy]),reconparams);
+    }
+
+    return (nloglike + reconparams->b_nearest * nlogprior_nearest + reconparams->b_diag * nlogprior_diag + reconparams->b_interslice * nlogprior_interslice) ;
 }
 
 
@@ -270,8 +258,8 @@ void forwardProject3D(
     
     if(A->Ncolumns != Nxy)
     {
-      fprintf(stderr,"Error in forwardProject3D : dimensions of System Matrix and Image are not compatible \n");
-      exit(-1);
+        fprintf(stderr,"Error in forwardProject3D : dimensions of System Matrix and Image are not compatible \n");
+        exit(-1);
     }
     
 
@@ -286,9 +274,7 @@ void forwardProject3D(
                 AValue = A_column.Value[n];
 
                 for(jz=0;jz<NSlices;jz++)   /* vary slice index */
-                {
-                  AX[jz][k] += AValue*X->image[jz][j] ; /* Voxel index = j+jz*Nxy */
-                }
+                    AX[jz][k] += AValue*X->image[jz][j] ; /* Voxel index = j+jz*Nxy */
             }
         }
     }

--- a/src/recon_3D.c
+++ b/src/recon_3D.c
@@ -50,12 +50,6 @@ void MBIRReconstruct3D(
     Nxy= Nx*Ny;
     M = sinogram->sinoparams.NViews * sinogram->sinoparams.NChannels ;
     
-    if(sinogram->sinoparams.NSlices != Nz)
-    {
-        fprintf(stderr,"Error in MBIRReconstruct3D: No. of slices in sinogram not equal to no. of slices in image \n");
-        exit(-1);
-    } 
-
     /********************************************/
     /* Forward Projection and Error Calculation */
     /********************************************/
@@ -215,12 +209,6 @@ float MAPCostFunction3D(
 
     Nxy = Nx*Ny;
     
-    if(sinogram->sinoparams.NSlices != Nz)
-    {
-        fprintf(stderr,"Error in MAPCostFunction3D: No. of slices in sinogram not equal to no. of slices in image \n");
-        exit(-1);
-    }    
-
 	nloglike = 0.0;
 
     for (jz = 0; jz < Nz; jz++)


### PR DESCRIPTION
Minor fix so that solely .imgparams file (Nz,FirstSliceNumber) specifies slice range for reconstruction.  It already did this, but it previously would exit if these field values were different from the slice range in .sinoparams.  Now .sinoparams can specifically describe the available data, and .imgparams can specify a sub-volume to reconstruct.

The other commits are some minor formatting changes and reorganization. Mainly certain operations in the image initialization were simplified and put in a more proper place.